### PR TITLE
fix: Do not validate insertion markers

### DIFF
--- a/src/fields/ValidationField.ts
+++ b/src/fields/ValidationField.ts
@@ -1,4 +1,4 @@
-import { FieldLabel } from "blockly"
+import { Block, FieldLabel } from "blockly"
 
 export interface ValidationFieldOptions {
     mandatory?: boolean
@@ -43,9 +43,12 @@ export class ValidationField extends FieldLabel {
         if (!connectedBlock || !connectedBlock.type.startsWith("lists_"))
             return true
 
-        const checkBlock = (block: any): boolean => {
+        const checkBlock = (block: Block): boolean => {
             if (!block) return false
-            if (!block.type.startsWith("lists_")) {
+            if (
+                !block.type.startsWith("lists_") &&
+                !block.isInsertionMarker()
+            ) {
                 return true // Non-list block found, array is non-empty
             }
 


### PR DESCRIPTION
In the normal field validation, I made sure that insertion markers are not used for validation. I would suggest doing the same for list blocks. Otherwise, we will get lots of jumping validation icons while dragging around. I would also assume that no further validation is possible with insertion markers (since they are not the block being dragged), so I guess it would be good practice to just ignore them