### PR TITLE
fix: Correct type checking on HMC profile block

### DIFF
--- a/src/blocks/hmc_profile.ts
+++ b/src/blocks/hmc_profile.ts
@@ -82,6 +82,9 @@ export const profile_hmc: HMCBlock = {
         const details = property.representationsAndSemantics[0]
         const isRepeatable = details.repeatable == "Yes"
 
+        const typeCheck = ["JSON", "String", "Boolean", "Number"]
+        if (isRepeatable) typeCheck.push("Array")
+
         const input = this.appendValueInput(property.name)
             .appendField(property.name)
             .appendField(
@@ -91,7 +94,7 @@ export const profile_hmc: HMCBlock = {
                 }),
                 `val-${property.name}`,
             )
-            .setCheck(isRepeatable ? ["Array", "JSON"] : ["JSON"])
+            .setCheck(typeCheck)
             .setAlign(1)
 
         if (details.obligation === "Optional") {


### PR DESCRIPTION
Now allowed are JSON, String, Number and Boolean. In case of repeatable Attributes, Array is also allowed

Closes #3 