### PR TITLE
Make output panel collapsible for better use on smaller screens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -27,7 +27,28 @@ code {
     width: 400px;
     flex: 0 0 400px;
     overflow: auto;
-    margin: 1rem;
+    padding: 0.5rem;
+    background: rgb(247, 240, 228);
+}
+
+#outputPane.collapsed {
+    display: none;
+}
+
+#collapseOutputPaneBtn {
+    width: 1em;
+    height: 100vh;
+    margin: auto 1px;
+    padding: 0.6em;
+    background: rgb(247, 240, 228);
+    border-radius: 0 6px 6px 0;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1em;
+    writing-mode: sideways-lr;
+    text-align: center;
 }
 
 #generatedCode {

--- a/src/index.html
+++ b/src/index.html
@@ -6,13 +6,26 @@
     </head>
     <body>
         <div id="pageContainer">
-            <div id="outputPane">
+            <div id="outputPane" class="collapsed">
                 <pre id="generatedCode"><code></code></pre>
             </div>
+            <button id="collapseOutputPaneBtn" title="Toggle output pane">
+                Show output pane
+            </button>
             <div id="blocklyDiv"></div>
             <div style="max-height: 100vh; width: 800px; overflow: scroll">
                 <unified-document class="jsonPicker"></unified-document>
             </div>
         </div>
+        <script>
+        const outputPane = document.getElementById('outputPane');
+        const btn = document.getElementById('collapseOutputPaneBtn');
+        btn.onclick = function() {
+            outputPane.classList.toggle('collapsed');
+            const collapsed = outputPane.classList.contains('collapsed');
+            btn.innerHTML = collapsed ? 'Show output pane' : 'Hide output pane';
+            btn.title = collapsed ? 'Show output pane' : 'Hide output pane';
+        };
+        </script>
     </body>
 </html>


### PR DESCRIPTION
I think it improves the UX of the prototype? The panel is hidden by default. Not sure if it obscures the purpose of the designer, though...