### PR TITLE
Spawn data access blocks in the middle of the screen on click

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -61,8 +61,8 @@ jsonPicker.addEventListener("keyClick", (e: Event) => {
     const offset = workspace.getOriginOffsetInPixels()
     block.moveTo(
         new Blockly.utils.Coordinate(
-            blocklyDiv.offsetWidth / 2 - offset.x,
-            blocklyDiv.offsetHeight / 2 - offset.y,
+            blocklyDiv.offsetWidth * 2 / 3 - offset.x,
+            blocklyDiv.offsetHeight / 3 - offset.y,
         ),
     )
     block.render()


### PR DESCRIPTION
Blocks now spawn in the middle of the current viewport. We could also look into spawning the block near the json picker, close to the entry that was clicked. I am not sure which one is better in terms of usability though. 

Closes #31 