### PR TITLE
List fixes: Allow lists with just one element and add code generation

### DIFF
--- a/lib/fields/ValidationField.ts
+++ b/lib/fields/ValidationField.ts
@@ -52,10 +52,14 @@ export class ValidationField extends FieldLabel {
                 return true // Non-list block found, array is non-empty
             }
 
-            // For list blocks, check all inputs recursively using functional approach
-            return block.inputList
-                .map((input) => input.connection?.targetBlock() ?? undefined)
-                .every((targetBlock) => checkBlock(targetBlock))
+            // For list blocks, check all attached blocks recursively
+            // Rule 1: All attached blocks must be valid
+            // Rule 2: If this field is mandatory Then at least one block must be attached
+            // (Note: This allows empty slots, they should just be ignored in code generation)
+            const listBlocks =  block.inputList
+                .map((input) => input.connection?.targetBlock() ?? undefined).filter(b => b !== undefined).filter(b => !b.isInsertionMarker())
+            return listBlocks
+                .every((targetBlock) => checkBlock(targetBlock)) &&  (this.options.mandatory ? listBlocks.length > 0 : true)
         }
 
         return checkBlock(connectedBlock)

--- a/lib/fields/ValidationField.ts
+++ b/lib/fields/ValidationField.ts
@@ -54,12 +54,12 @@ export class ValidationField extends FieldLabel {
 
             // For list blocks, check all attached blocks recursively
             // Rule 1: All attached blocks must be valid
-            // Rule 2: If this field is mandatory Then at least one block must be attached
+            // Rule 2: At least one block must be attached
             // (Note: This allows empty slots, they should just be ignored in code generation)
             const listBlocks =  block.inputList
                 .map((input) => input.connection?.targetBlock() ?? undefined).filter(b => b !== undefined).filter(b => !b.isInsertionMarker())
             return listBlocks
-                .every((targetBlock) => checkBlock(targetBlock)) &&  (this.options.mandatory ? listBlocks.length > 0 : true)
+                .every((targetBlock) => checkBlock(targetBlock)) &&  listBlocks.length > 0
         }
 
         return checkBlock(connectedBlock)

--- a/lib/generators/python.ts
+++ b/lib/generators/python.ts
@@ -292,3 +292,21 @@ forBlock["profile_hmc_reference_block"] = function (block: Blockly.Block) {
     const code = `"${dropdown_attribute}"`
     return [code, Order.ATOMIC]
 }
+
+forBlock["lists_create_with"] = function <T extends Util.FairDoCodeGenerator>(block: Blockly.Block, generator: T) {
+    const values: string[] = []
+    for (const input of block.inputList) {
+        const block = input.connection?.targetBlock()
+        if (block) {
+            // TODO: Do we have to consider the operator precedence here?
+            const result = generator.blockToCode(block)
+            if (typeof result === "string") {
+                values.push(result)
+            } else {
+                values.push(result[0])
+            }
+        }
+    }
+
+    return ["[" + values.join(", ") + "]", Order.COLLECTION]
+}


### PR DESCRIPTION
Closes #43 
Closes #35 

Array blocks are now valid if:
 1. Every attached block is valid
 2. At least one block is attached

This way, empty slots are ignored. Non-mandatory properties should be removed rather than leaving the array empty. This is consistent with non-array non-mandatory fields being invalid when left empty.

Code generation is "fixed" by manually implementing it. One issue I noticed: The generator puts the resulting list in brackets `([...])` when setting the operator precedence to `Order.COLLECTION`, that is probably not intended. Could not find the source of this problem.