### PR TITLE
Update colors of blocks, switch to modern renderer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -64,6 +64,10 @@ code {
   overflow: auto;
 }
 
+g.blocklyDisabled g.blocklyLabelField text.blocklyText {
+  fill: rgb(40, 40, 40);
+}
+
 g > image[alt="Click to remove this property"], g > image.base-icon {
   filter: invert(1);
   transform: translate(-1px, -1px);

--- a/components/Workspace.tsx
+++ b/components/Workspace.tsx
@@ -40,6 +40,7 @@ export function Workspace() {
         const workspace = Blockly.inject(divRef.current, {
             rtl: false,
             toolbox,
+            renderer: "thrasos",
             grid: { spacing: 20, length: 3, colour: "#ccc", snap: true },
             plugins: {
                 connectionPreviewer: BlockDynamicConnection.decoratePreviewer(
@@ -56,7 +57,7 @@ export function Workspace() {
 
         workspace.registerButtonCallback("dataAccessToolboxHelp", () => {
             alert(
-                "Use the Data Access tab on the right side to create Data Access blocks by clicking or drag-and-drop",
+                "Use the Data Access tab on the right side to create Data Access blocks by clicking or dragging-and-dropping JSON keys",
             )
         })
 

--- a/lib/blocks/attribute.ts
+++ b/lib/blocks/attribute.ts
@@ -1,55 +1,57 @@
-import * as Blockly from "blockly/core";
+import * as Blockly from "blockly/core"
 
 export const attribute = {
-  type: "attribute_key",
-  tooltip: "asdf",
-  helpUrl:
-    "https://dtr-test.pidconsortium.net/#objects/21.T11148/b9b76f887845e32d29f7",
-  message0: "%1 On failure %2 %3 %4 %5",
-  args0: [
-    {
-      type: "field_label_serializable",
-      text: "digitalObjectLocation",
-      name: "name",
-    },
-    {
-      type: "field_dropdown",
-      name: "on_fail",
-      options: [
-        ["stop", "fail-stop"],
-        ["continue silent", "fail-continue"],
-        ["continue with warning", "fail-warn"],
-      ],
-    },
-    {
-      type: "input_value",
-      name: "slot",
-      check: "String",
-    },
-    {
-      type: "field_input",
-      name: "pid",
-      text: "21.11152/a3f19b32-4550-40bb-9f69-b8ffd4f6d0ea",
-    },
-    {
-      type: "input_dummy",
-      name: "NAME",
-    },
-  ],
-  previousStatement: ["attribute_key", "profile"],
-  nextStatement: ["attribute_key", "profile"],
-  colour: 285,
-  inputsInline: false,
-};
+    type: "attribute_key",
+    tooltip: "asdf",
+    helpUrl:
+        "https://dtr-test.pidconsortium.net/#objects/21.T11148/b9b76f887845e32d29f7",
+    message0: "%1 On failure %2 %3 %4 %5",
+    args0: [
+        {
+            type: "field_label_serializable",
+            text: "digitalObjectLocation",
+            name: "name",
+        },
+        {
+            type: "field_dropdown",
+            name: "on_fail",
+            options: [
+                ["stop", "fail-stop"],
+                ["continue silent", "fail-continue"],
+                ["continue with warning", "fail-warn"],
+            ],
+        },
+        {
+            type: "input_value",
+            name: "slot",
+            check: "String",
+        },
+        {
+            type: "field_input",
+            name: "pid",
+            text: "21.11152/a3f19b32-4550-40bb-9f69-b8ffd4f6d0ea",
+        },
+        {
+            type: "input_dummy",
+            name: "NAME",
+        },
+    ],
+    previousStatement: ["attribute_key", "profile"],
+    nextStatement: ["attribute_key", "profile"],
+    colour: 230,
+    inputsInline: false,
+}
 
 export const backlink_declaration = {
-  init: function() {
-    this.appendValueInput('ATTRIBUTE_KEY')
-    .setCheck(['attribute_key', 'String'])
-      .appendField('Inverse reference to attribute');
-    this.setOutput(true, 'BackwardLinkFor');
-    this.setTooltip('Adds reverse references (backlinks) if another record links to this record using the given attribute key.');
-    this.setHelpUrl('');
-    this.setColour(225);
-  }
-} as Blockly.Block;
+    init: function () {
+        this.appendValueInput("ATTRIBUTE_KEY")
+            .setCheck(["attribute_key", "String"])
+            .appendField("Inverse reference to attribute")
+        this.setOutput(true, "BackwardLinkFor")
+        this.setTooltip(
+            "Adds reverse references (backlinks) if another record links to this record using the given attribute key.",
+        )
+        this.setHelpUrl("")
+        this.setColour(120)
+    },
+} as Blockly.Block

--- a/lib/blocks/error_handling.ts
+++ b/lib/blocks/error_handling.ts
@@ -13,7 +13,7 @@ export const stop_design = {
             "Throws an error and stops the execution of the design. No PID will be created. Use for irreparable situations which you do not expect to happen.",
         )
         this.setHelpUrl("")
-        this.setColour(345)
+        this.setColour(360)
     },
 } as Blockly.Block
 
@@ -29,7 +29,7 @@ export const log_value = {
             "Print given information and continue. Continues in any case (no cancellation)!",
         )
         this.setHelpUrl("")
-        this.setColour(0)
+        this.setColour(160)
     },
 } as Blockly.Block
 

--- a/lib/blocks/hmc_profile.ts
+++ b/lib/blocks/hmc_profile.ts
@@ -45,23 +45,24 @@ export const profile_hmc: HMCBlock = {
             ["-- Add Property --", "ADD"] as [string, string],
             ...this.profile.properties
                 .filter(
-                    (property) => property.representationsAndSemantics[0]
-                        .obligation === "Optional"
+                    (property) =>
+                        property.representationsAndSemantics[0].obligation ===
+                        "Optional",
                 )
                 .map(
-                    (property) => [camelToTitleCase(property.name), property.name] as [
-                        string,
-                        string
-                    ]
+                    (property) =>
+                        [camelToTitleCase(property.name), property.name] as [
+                            string,
+                            string,
+                        ],
                 ),
-        ]);
-        optionalPropertiesSelector.setTooltip("Adds optional properties of this profile to your record.")
+        ])
+        optionalPropertiesSelector.setTooltip(
+            "Adds optional properties of this profile to your record.",
+        )
 
         this.appendDummyInput("DUMMY-DROPDOWN")
-            .appendField(
-                optionalPropertiesSelector,
-                "DROPDOWN",
-            )
+            .appendField(optionalPropertiesSelector, "DROPDOWN")
             .setAlign(0)
 
         this.setInputsInline(false)
@@ -95,11 +96,14 @@ export const profile_hmc: HMCBlock = {
         ]
         if (isRepeatable) typeCheck.push("Array")
 
-        const nameLabel = new Blockly.FieldLabel(camelToTitleCase(property.name))
+        const nameLabel = new Blockly.FieldLabel(
+            camelToTitleCase(property.name),
+        )
         nameLabel.setTooltip(property.name + " / " + property.identifier)
 
-        const input = this.appendValueInput(property.name)
-            .appendField(nameLabel)
+        const input = this.appendValueInput(property.name).appendField(
+            nameLabel,
+        )
 
         if (details.obligation === "Optional") {
             const tooltip = "Click to remove this property"
@@ -109,7 +113,7 @@ export const profile_hmc: HMCBlock = {
                 16,
                 tooltip,
                 () => this.removeFieldForProperty(propertyName),
-            );
+            )
             image.setTooltip(tooltip)
             input.appendField(image, "trash_icon")
         }
@@ -180,7 +184,7 @@ export const profile_hmc: HMCBlock = {
                     `References an attribute key which appears in ${profileName}.`,
                 )
                 this.setHelpUrl("")
-                this.setColour(225)
+                this.setColour(120)
             },
         } as Blockly.Block
     },

--- a/lib/blocks/input.ts
+++ b/lib/blocks/input.ts
@@ -30,7 +30,7 @@ export const input_jsonpath: InputJsonPath = {
         )
         this.setHelpUrl("")
         this.setOutput(true, null)
-        this.setColour(230)
+        this.setColour(210)
     },
 
     customContextMenu(menu) {
@@ -99,15 +99,15 @@ export const input_custom_json: Blockly.BlockSvg = {
         this.appendValueInput("QUERY")
             .setCheck("String")
             .appendField(
-                new Blockly.FieldLabelSerializable("JSON Query"),
+                new Blockly.FieldLabelSerializable("Custom Query"),
                 "NAME",
             )
         this.setInputsInline(true)
         this.setOutput(true, "JSON")
         this.setTooltip(
-            "Execute a custom JSON Query against the current Source Document",
+            "Execute a custom jsonpath query against the current Source Document",
         )
         this.setHelpUrl("")
-        this.setColour(315)
+        this.setColour(210)
     },
 }

--- a/lib/blocks/pidrecord.ts
+++ b/lib/blocks/pidrecord.ts
@@ -1,61 +1,63 @@
 export const pidrecord = {
-  type: "pidrecord",
-  tooltip: "Defines a PID record, which holds a set of attributes and profiles.",
-  helpUrl: "",
-  message0: "PID Record %1 %2 Local ID (pseudo-pid) %3 %4",
-  args0: [
-    {
-      type: "field_label_serializable",
-      text: "(no PID yet)",
-      name: "pid",
-    },
-    {
-      type: "input_dummy",
-      name: "label",
-    },
-    {
-      type: "input_value",
-      name: "local-id",
-    },
-    {
-      type: "input_statement",
-      name: "record",
-      check: ["profile", "attribute_key"],
-    },
-  ],
-  colour: 330,
-  inputsInline: false,
-};
+    type: "pidrecord",
+    tooltip:
+        "Defines a PID record, which holds a set of attributes and profiles.",
+    helpUrl: "",
+    message0: "PID Record %1 %2 Local ID (pseudo-pid) %3 %4",
+    args0: [
+        {
+            type: "field_label_serializable",
+            text: "(no PID yet)",
+            name: "pid",
+        },
+        {
+            type: "input_dummy",
+            name: "label",
+        },
+        {
+            type: "input_value",
+            name: "local-id",
+        },
+        {
+            type: "input_statement",
+            name: "record",
+            check: ["profile", "attribute_key"],
+        },
+    ],
+    colour: 300,
+    inputsInline: false,
+}
 
 export const pidrecord_skipable = {
-  type: "pidrecord_skipable",
-  tooltip: "Defines a PID record, which holds a set of attributes and profiles. It can be skipped based on a condition.",
-  helpUrl: "",
-  message0: "PID Record %1 %2 Local ID (pseudo-pid) %3 %4 Skip if %5",
-  args0: [
-    {
-      type: "field_label_serializable",
-      text: "(no PID yet)",
-      name: "pid",
-    },
-    {
-      type: "input_dummy",
-      name: "label",
-    },
-    {
-      type: "input_value",
-      name: "local-id",
-    },
-    {
-      type: "input_statement",
-      name: "record",
-      check: ["profile", "attribute_key"],
-    },
-    {
-      type: "input_value",
-      name: "skip-condition",
-    },
-  ],
-  colour: 330,
-  inputsInline: false,
-};
+    type: "pidrecord_skipable",
+    tooltip:
+        "Defines a PID record, which holds a set of attributes and profiles. It can be skipped based on a condition.",
+    helpUrl: "",
+    message0: "PID Record %1 %2 Local ID (pseudo-pid) %3 %4 Skip if %5",
+    args0: [
+        {
+            type: "field_label_serializable",
+            text: "(no PID yet)",
+            name: "pid",
+        },
+        {
+            type: "input_dummy",
+            name: "label",
+        },
+        {
+            type: "input_value",
+            name: "local-id",
+        },
+        {
+            type: "input_statement",
+            name: "record",
+            check: ["profile", "attribute_key"],
+        },
+        {
+            type: "input_value",
+            name: "skip-condition",
+        },
+    ],
+    colour: 300,
+    inputsInline: false,
+}

--- a/lib/toolbox.ts
+++ b/lib/toolbox.ts
@@ -17,8 +17,8 @@ export const toolbox = {
     contents: [
         {
             kind: "category",
-            name: "Profiles",
-            categorystyle: "procedure_category",
+            name: "Records & Profiles",
+            colour: 230,
             contents: [
                 {
                     kind: "block",
@@ -40,45 +40,15 @@ export const toolbox = {
         },
         {
             kind: "category",
-            name: "Data Access",
-            categorystyle: "procedure_category",
-            contents: [
-                {
-                    kind: "label",
-                    text: "For Expert use",
-                },
-                {
-                    kind: "block",
-                    type: "input_custom_json",
-                    inputs: {
-                        QUERY: {
-                            shadow: {
-                                type: "text",
-                                fields: {
-                                    TEXT: "JSON.property",
-                                },
-                            },
-                        },
-                    },
-                },
-                {
-                    kind: "button",
-                    text: "Help",
-                    callbackKey: "dataAccessToolboxHelp",
-                },
-            ],
+            name: "Automatic backlinks",
+            colour: 120,
+            custom: "BACKLINKS",
         },
         {
             kind: "category",
             name: "Checks and Errors",
-            categorystyle: "procedure_category",
+            colour: "gray",
             custom: "ERRORS",
-        },
-        {
-            kind: "category",
-            name: "Automatic backlinks",
-            categorystyle: "procedure_category",
-            custom: "BACKLINKS",
         },
         {
             kind: "sep",
@@ -115,6 +85,10 @@ export const toolbox = {
                 {
                     kind: "block",
                     type: "logic_ternary",
+                },
+                {
+                    kind: "block",
+                    type: "otherwise",
                 },
             ],
         },
@@ -398,6 +372,10 @@ export const toolbox = {
                 },
                 {
                     kind: "block",
+                    type: "log_value",
+                },
+                {
+                    kind: "block",
                     type: "text_join",
                 },
                 {
@@ -678,6 +656,36 @@ export const toolbox = {
             name: "Functions",
             categorystyle: "procedure_category",
             custom: "PROCEDURE",
+        },
+        {
+            kind: "category",
+            name: "Data Access",
+            colour: 280,
+            contents: [
+                {
+                    kind: "label",
+                    text: "For Expert use",
+                },
+                {
+                    kind: "block",
+                    type: "input_custom_json",
+                    inputs: {
+                        QUERY: {
+                            shadow: {
+                                type: "text",
+                                fields: {
+                                    TEXT: "$.customProperty",
+                                },
+                            },
+                        },
+                    },
+                },
+                {
+                    kind: "button",
+                    text: "Help",
+                    callbackKey: "dataAccessToolboxHelp",
+                },
+            ],
         },
     ],
 }


### PR DESCRIPTION
Closes #41 #14 

I did not necessarily implement a schema, I just adjusted the colors of our custom blocks to be consistent. I also added some custom blocks to the existing categories of the toolbox.

I also changed the renderer to the recommended `thrasos` renderer, which looks pretty nice I think.

Example image:
<img width="666" height="588" alt="grafik" src="https://github.com/user-attachments/assets/4778b0aa-6fca-4c67-b79f-d88b85af69d8" />
 - Print block now has color of Text blocks
 - "otherwise" block now has color of logic blocks
 - Profiles and attributes are dark blue
 - Records are purple
 - Data access is light blue

Rearranged toolbar:
<img width="183" height="315" alt="grafik" src="https://github.com/user-attachments/assets/49c77f0d-bce0-41fd-b1ff-889617d4b10d" />

I put Data Access at the very bottom, because it only contains the custom query block that should only rarely be used. As it will probably be used with variables and procedures, I think it makes sense down there.

Disabled blocks:
<img width="361" height="51" alt="grafik" src="https://github.com/user-attachments/assets/5d548327-109a-4b91-86eb-aa9555c56096" />
Changed the text color as discussed in #41 . Does not really look pretty but solves the readability issue, without the hassle of a custom renderer