### PR TITLE
Fix block overlap in toolbox

### DIFF
--- a/lib/blocks/hmc_profile.ts
+++ b/lib/blocks/hmc_profile.ts
@@ -199,6 +199,11 @@ export const profile_hmc: HMCBlock = {
             listBlock.initSvg()
             listBlock.render()
 
+            if ("minus" in listBlock && typeof listBlock.minus === "function") {
+                listBlock.minus()
+                listBlock.minus()
+            }
+
             // Connect the list block to the input
             const connection = input.connection
             if (connection && listBlock.outputConnection) {


### PR DESCRIPTION
Closes #84 

**Reason for the problem**: Change events from the validation field cause the toolbox to re-evaluate its size. This does not happen for other events (like connect events, that still come from the list block).

**Solution to the problem**: Instead of hacking in a change event, I decided to just not add the list block while the profile is still in the toolbox. This also reduced the visual complexity of the toolbox, which is good in this case

I also decided to make the list block smaller (only 1 input), as this reduces layout shifting and looks better in my opinion. As the plus and minus buttons are quite big and the block is clearly labeled as a list, I don't think this would cause problems.

I would also be fine with just sizing it down to 2 inputs 😄