### PR TITLE
feat: indicate uniqueness of data source picker entry

### DIFF
--- a/components/data-source-picker/Entry.tsx
+++ b/components/data-source-picker/Entry.tsx
@@ -1,6 +1,6 @@
 import { DocumentEntry } from "@/lib/data-source-picker/json-unifier"
 import { Button } from "@/components/ui/button"
-import { ArrowLeft, StarIcon } from "lucide-react"
+import { ArrowLeft, FingerprintIcon } from "lucide-react"
 import { ValueRenderer } from "@/components/data-source-picker/ValueRenderer"
 import {
     useCallback,
@@ -101,13 +101,13 @@ export function Entry({
                                 current={entry.timesObserved}
                             />
                             {isUnique && (
-                                <Tooltip delayDuration={700}>
+                                <Tooltip>
                                     <TooltipTrigger asChild>
-                                        <StarIcon className="size-3.5 shrink-0 text-primary" />
+                                        <FingerprintIcon className="ml-1 size-4 shrink-0 text-primary" />
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        All found entries in this field are
-                                        unique
+                                        The values of this entry are unique in
+                                        each provided file
                                     </TooltipContent>
                                 </Tooltip>
                             )}

--- a/components/data-source-picker/Entry.tsx
+++ b/components/data-source-picker/Entry.tsx
@@ -101,13 +101,15 @@ export function Entry({
                                 current={entry.timesObserved}
                             />
                             {isUnique && (
-                                <Tooltip>
+                                <Tooltip delayDuration={700}>
                                     <TooltipTrigger asChild>
                                         <FingerprintIcon className="ml-1 size-4 shrink-0 text-primary" />
                                     </TooltipTrigger>
-                                    <TooltipContent>
-                                        The values of this entry are unique in
-                                        each provided file
+                                    <TooltipContent className="max-w-96">
+                                        The values of this entry are different
+                                        in each provided file. Therefore, this
+                                        value might be suitable as an
+                                        identifier.
                                     </TooltipContent>
                                 </Tooltip>
                             )}

--- a/components/data-source-picker/Entry.tsx
+++ b/components/data-source-picker/Entry.tsx
@@ -1,6 +1,6 @@
 import { DocumentEntry } from "@/lib/data-source-picker/json-unifier"
 import { Button } from "@/components/ui/button"
-import { ArrowLeft } from "lucide-react"
+import { ArrowLeft, StarIcon } from "lucide-react"
 import { ValueRenderer } from "@/components/data-source-picker/ValueRenderer"
 import {
     useCallback,
@@ -9,6 +9,7 @@ import {
     useEffect,
     useState,
     Fragment,
+    useMemo,
 } from "react"
 import { AvailabilityScale } from "@/components/data-source-picker/AvailabilityScale"
 import {
@@ -44,6 +45,15 @@ export function Entry({
             return () => observer.disconnect()
         }
     }, [])
+
+    // Whether all the observed values in the merged document entry are unique.
+    // This indicates that this value can be well-used for identifiers and the likes.
+    const isUnique = useMemo(() => {
+        return (
+            entry.observedValues.values().every((v) => v === 1) &&
+            entry.timesObserved === totalDocuments
+        )
+    }, [entry.observedValues, entry.timesObserved, totalDocuments])
 
     const onDragStart = useCallback(
         (e: DragEvent) => {
@@ -90,6 +100,17 @@ export function Entry({
                                 total={totalDocuments}
                                 current={entry.timesObserved}
                             />
+                            {isUnique && (
+                                <Tooltip delayDuration={700}>
+                                    <TooltipTrigger asChild>
+                                        <StarIcon className="size-3.5 shrink-0 text-primary" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                        All found entries in this field are
+                                        unique
+                                    </TooltipContent>
+                                </Tooltip>
+                            )}
                         </div>
                         <Tooltip delayDuration={700}>
                             <TooltipTrigger asChild>


### PR DESCRIPTION
<img width="769" height="549" alt="grafik" src="https://github.com/user-attachments/assets/fd0c8069-40cf-4eb7-aeaf-2ec845d0ffd3" />

Alternatives to the star icon could be:
- [Fingerprint](https://lucide.dev/icons/fingerprint-pattern)
- [DNA Helix](https://lucide.dev/icons/dna)
- [Sparkle](https://lucide.dev/icons/sparkle) (I thought it looked odd though)
- [Snowflake](https://lucide.dev/icons/snowflake)

Merging to main as development is very out of date 😄 