### PR TITLE
feat: data input blocks check if their path is valid

### DIFF
--- a/components/Workspace.tsx
+++ b/components/Workspace.tsx
@@ -111,7 +111,8 @@ export function Workspace() {
             workspace.getAllBlocks().forEach((block) => {
                 if (
                     block.type === "profile_hmc" ||
-                    block.type === "attribute_key"
+                    block.type === "attribute_key" ||
+                    block.type === "input_json_pointer"
                 ) {
                     const fields = Array.from(block.getFields())
                     for (const field of fields) {

--- a/lib/blocks/input.tsx
+++ b/lib/blocks/input.tsx
@@ -10,6 +10,7 @@ import {
 import { dataSourcePickerStore } from "@/lib/stores/data-source-picker-store"
 import { JSONValues } from "@/lib/data-source-picker/json-unifier"
 import { alertStore } from "@/lib/stores/alert-store"
+import { ValidationField } from "@/lib/fields/ValidationField"
 
 export interface InputJsonPointer extends Blockly.BlockSvg {
     path: PathSegment[]
@@ -50,6 +51,14 @@ export const input_json_pointer: InputJsonPointer = {
             .appendField("Read")
             .appendField("JSON", "DISPLAY_QUERY")
             .appendField(hiddenQueryField, "QUERY")
+            .appendField(
+                new ValidationField({
+                    customCheck: async () => {
+                        const queryResults = this.executeQuery()
+                        return queryResults.length > 0
+                    },
+                }),
+            )
         this.setTooltip(
             "Read value from Source Document. Right-click for more.",
         )


### PR DESCRIPTION
<img width="960" height="427" alt="grafik" src="https://github.com/user-attachments/assets/844be0ce-9725-4840-b051-6ba14ad8f27d" />

Very simple implementation. Uses the existing ValidationField and simply executes the query encoded in the block and checks if there are any results

closes #134 